### PR TITLE
Fix compilation for newer kernels

### DIFF
--- a/fthd_v4l2.c
+++ b/fthd_v4l2.c
@@ -22,6 +22,7 @@
 #include <linux/sched.h>
 #include <linux/wait.h>
 #include <linux/delay.h>
+#include <linux/version.h>
 #include <linux/videodev2.h>
 #include <media/v4l2-dev.h>
 #include <media/v4l2-ioctl.h>
@@ -41,7 +42,9 @@
 #define FTHD_NUM_FORMATS 2 /* NV16 is disabled for now */
 
 static int fthd_buffer_queue_setup(struct vb2_queue *vq,
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(4,4,0)
 				   const struct v4l2_format *fmt,
+#endif
 				   unsigned int *nbuffers, unsigned int *nplanes,
 				   unsigned int sizes[], void *alloc_ctxs[])
 {
@@ -55,10 +58,6 @@ static int fthd_buffer_queue_setup(struct vb2_queue *vq,
 		return -EINVAL;
 
 	/* FIXME: We assume single plane format here but not below */
-	if (fmt && fmt->fmt.pix.sizeimage <
-	    (cur_fmt->bytesperline * cur_fmt->height))
-		return -EINVAL;
-
 	for (i = 0; i < *nplanes; i++) {
 		sizes[i] = cur_fmt->sizeimage;
 		alloc_ctxs[i] = dev_priv->alloc_ctx;


### PR DESCRIPTION
New kernels above 4.4 have a different interface for
vb2_ops.queue_setup, so we respect that.

Tested on 4.6.0, the camera works ok.
